### PR TITLE
User endpoint created

### DIFF
--- a/usermgt/admin.py
+++ b/usermgt/admin.py
@@ -8,7 +8,7 @@ class UserAdmin(UserAdminBase):
     form = UserChangeForm
     fieldsets = (
         (None, {'fields': ('email', 'password', )}),
-        ('Personal info', {'fields': ('first_name', 'last_name')}),
+        ('Personal info', {'fields': ('username', 'first_name', 'last_name')}),
         ('Permissions', {'fields': ('is_active', 'is_staff',
                                     'is_superuser', 'groups', 'user_permissions')}),
         ('Important dates', {'fields': ('last_login', 'date_joined')}),

--- a/usermgt/serializers.py
+++ b/usermgt/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework.serializers import ModelSerializer
+from .models import User
+
+
+class UserSerializer(ModelSerializer):
+    class Meta:
+        model = User
+        lookup_field = 'username'
+        fields = ['username', 'first_name', 'last_name', 'email',
+                  'role', 'department', 'extension', 'position']

--- a/usermgt/tests.py
+++ b/usermgt/tests.py
@@ -1,3 +1,67 @@
-from django.test import TestCase
+import json
+from django.test import tag
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rest_framework.viewsets import reverse
+from usermgt.models import User
 
-# Create your tests here.
+
+def createUser(key=1):
+    username = 'testuser{}'.format(key)
+    password = 'testuserpw{}'.format(key)
+    email = 'testuser{}@email.com'.format(key)
+    user = User.objects.create_user(username, email, password)
+    return user
+
+
+@tag('user')
+class UserEndpointTests(APITestCase):
+    def createUserAndLogin(self, username='testinguser', password='testinguserpw', email='testinguser@email.com'):
+        user = User.objects.create_user(username, email, password)
+        loginPostData = {
+            'email': email,
+            'password': password
+        }
+        url = reverse('login')
+        response = self.client.post(url, loginPostData, format='json')
+        jsonResponse = json.loads(response.content)
+        accessToken = jsonResponse['access']
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + accessToken)
+
+    def tearDown(self):
+        """Clear credentials at the end of each test case"""
+        self.client.credentials()
+
+    # GET user/
+    @tag('current')
+    def test_retrieveUsers(self):
+        # Populate the database with sample data
+        createUser(1)
+
+        # Try without logging in. It should give a 401 error
+        url = reverse('user-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        # Try after loggin in. This time it should be successful.
+        self.createUserAndLogin()
+        response = self.client.get(url, format='json')
+        # 200 status code. Total users = 2. (Created user + logged in user)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+
+    # GET user/xxx/
+    def test_retrieveOneUser(self):
+        self.fail()
+
+    # POST user/
+    def test_createUser(self):
+        self.fail()
+
+    # PUT user/xxx/
+    def test_updateUser(self):
+        self.fail()
+
+    # DELETE user/xxx/
+    def test_deleteUser(self):
+        self.fail()

--- a/usermgt/urls.py
+++ b/usermgt/urls.py
@@ -13,5 +13,5 @@ urlpatterns = [
 ]
 
 router = DefaultRouter()
-router.register('', views.UserViewSet)
+router.register('', views.UserViewSet, basename='user')
 urlpatterns += router.urls

--- a/usermgt/urls.py
+++ b/usermgt/urls.py
@@ -1,10 +1,17 @@
 from django.urls import path
+from rest_framework.routers import DefaultRouter
 from rest_framework_simplejwt import views as jwt_views
 from . import views
+
 
 urlpatterns = [
     path('login/', jwt_views.TokenObtainPairView.as_view(), name='login'),
     path('refreshtoken/', jwt_views.TokenRefreshView.as_view(), name='token-refresh'),
     path('public/', views.UnprotectedView.as_view(), name='public-view'),
     path('secret/', views.ProtectedView.as_view(), name='secret-view'),
+
 ]
+
+router = DefaultRouter()
+router.register('', views.UserViewSet)
+urlpatterns += router.urls

--- a/usermgt/views.py
+++ b/usermgt/views.py
@@ -1,15 +1,27 @@
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ModelViewSet
+from .models import User
+from .serializers import UserSerializer
+
+
+class UserViewSet(ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    lookup_field = 'username'
+    permission_classes = [IsAuthenticated, ]
+
 
 class UnprotectedView(APIView):
     def get(self, request):
-        response = {'message' : 'Unprotected view'}
+        response = {'message': 'Unprotected view'}
         return Response(response)
+
 
 class ProtectedView(APIView):
     permission_classes = (IsAuthenticated,)
+
     def get(self, request):
         response = {'message': 'Protected view'}
         return Response(response)
-


### PR DESCRIPTION
## Users endpoint

The users endpoint supports the following operations:
- GET `user/` List all users.
- POST `user/` Create new user (provide username, email, password).
- GET `user/<username>/` Get user by username.
- PUT `user/<username>/` Update user.
- DELETE `user/<username>/` Delete user.

Currently, the authentication system allows any logged in user to perform CRUD operations. This is enough for testing I hope. Need everyone's input to define authentication better.

I will add OpenAPI documentation soon.

Previously added authentication and testing endpoints are also available:
- POST `user/login/` Get JWT tokens (provide email and password).
- POST `user/refreshtoken/` Refresh JWT access token (provide refresh token).
- GET `user/public/` A public endpoint accessible by everyone.
- GET `user/secret/` A protected endpoint only accessible when logged in.

#### Testing

I have added unit tests for current endpoints. Run them with `python manage.py test -v 2`

#### Commit history
- Added users endpoint
- Test case layout + get all users test
- test: get one user and create user endpoints
- test: tests for user update and delete endpoints
